### PR TITLE
fix: Use correct internal link syntax and update Zola to 19.2

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,7 +9,7 @@ jobs:
       - name: checkout
         uses: actions/checkout@v4
       - name: build_and_deploy
-        uses: shalzz/zola-deploy-action@v0.18.0
+        uses: shalzz/zola-deploy-action@v0.19.2
         env:
           # Target branch
           PAGES_BRANCH: gh-pages

--- a/config.toml
+++ b/config.toml
@@ -11,7 +11,7 @@ output_dir = "build"
 # Whether to automatically compile all Sass files in the sass directory
 compile_sass = true
 
-generate_feed = true
+generate_feeds = true
 
 [markdown]
 # Whether to do syntax highlighting

--- a/content/2017-12-28-Setting-up-Jekyll.md
+++ b/content/2017-12-28-Setting-up-Jekyll.md
@@ -9,7 +9,7 @@ extra: {audience: developers}
 Jekyll is a wonderful program. The more I use it, the more I like it.
 It's customizable, automatically parses markdown, and uses a template system
 that makes it very easy to create a consistent style. Its only flaw is that
-it depends on [rubygems]({{ site.baseurl }}{% link _posts/2017-12-28-Setting-up-Jekyll.md %}#appendix).
+it depends on [rubygems](@/2017-12-28-Setting-up-Jekyll.md#appendix).
 
 Jekyll does get a little getting used to, however.
 In this article, I'll go over the basics:
@@ -24,7 +24,7 @@ and the commandline, which will be covered in another post.
 ## Installing
 If you don't have [rubygems](https://www.ruby-lang.org/en/documentation/installation/)
 installed, you'll need it. See also 
-[footnote 1]({{ site.baseurl }}{% link _posts/2017-12-28-Setting-up-Jekyll.md %}#appendix).
+[footnote 1](@/2017-12-28-Setting-up-Jekyll.md#appendix).
 
 ```sh
 gem install jekyll

--- a/content/2018-02-24-Password-Safety.md
+++ b/content/2018-02-24-Password-Safety.md
@@ -24,8 +24,7 @@ and [multi-factor auth](https://en.wikipedia.org/wiki/Multi-factor_authenticatio
 but most peoples' response is to either write sticky notes of passwords,
 or ignore the problem altogether.
 
-This does work if you don't [leave your passwords lying around](
-{{ site.baseurl }}{% link /assets/password.jpg %}).
+This does work if you don't [leave your passwords lying around](/assets/password.jpg).
 It is inconvenient, however, and doesn't scale to a large password database.
 What you should be using is a [password manager][manager].
 

--- a/content/2018-06-09-Rewriting-Jython.md
+++ b/content/2018-06-09-Rewriting-Jython.md
@@ -14,7 +14,7 @@ You can reuse Java code and still get the readability and conciseness of python.
 
 I was thinking about types in Python, particularly how it allows
 primitive operators to be overridden (+-/*%). For those unfamiliar with Python classes,
-check out my [previous post]({% link _posts/2018-03-03-Object-Oriented-Python.md %});
+check out my [previous post](@/2018-03-03-Object-Oriented-Python.md);
 essentially it uses methods like `__add__`, `__sub__`, etc. as interfaces.
 This lets you do things like
 ```python
@@ -56,7 +56,7 @@ duck typing more clearly.
 Because this is a toy project (and because parsing is hard), I have not implemented
 an interpreter; the sample usage would be `add(new NumberWrapper(5), new NumberWrapper(-.14))`.
 
-The full code is available [here]({% link assets/jython.java %}).
+The full code is available [here](/assets/jython.java).
 Its output is as follows:
 ```
 $ javac jython.java -Xlint:unchecked

--- a/content/2018-09-29-Reverse-Engineering-x86-assembly.md
+++ b/content/2018-09-29-Reverse-Engineering-x86-assembly.md
@@ -102,4 +102,4 @@ Continuing.
 [Inferior 1 (process 29542) exited normally]
 ```
 
-This post is continued in [Buffer Overflows and Stacks and Assembly, Oh My]({% link _posts/2019-04-29-Buffer-Overflows-and-Stacks-and-Assembly-Oh-My.md %}).
+This post is continued in [Buffer Overflows and Stacks and Assembly, Oh My](@/2019-04-29-Buffer-Overflows-and-Stacks-and-Assembly-Oh-My.md).

--- a/content/about/_index.md
+++ b/content/about/_index.md
@@ -1,8 +1,5 @@
 ---
 title: about
-permalink: /about/
-# template: page.html
-# page_template: page.html
 ---
 
 this section is undergoing reconstruction. for now, see [things that bring me wonder](@/2023-12-20-wonder.md).


### PR DESCRIPTION
I noticed on your website that the internal links on pages like "Rewriting Jython" were broken and figured out why. It looks like you were using some syntax from some other SSG probably before porting it to Zola. I switched them to use Zola's corresponding syntaxes and verified that they appear to work.

I couldn't get Zola 18.0 to build on my machine due to a dependency on time=0.3.30 which isn't building on rustc 1.80.1 for me. So I updated Zola to 0.19.2 which is the latest release.

Feel free to split these into separate PRs. This is just what was easiest for me ¯\_(ツ)_/¯